### PR TITLE
add support for root-node

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -27,6 +27,7 @@ var (
 	outputFile      = kingpin.Flag("out-file", "filename for output; default is <schema>_schematype.go").Short('o').String()
 	packageName     = kingpin.Flag("package", `package name for generated file; default is "main"`).Default("main").String()
 	rootTypeName    = kingpin.Flag("root-type", `name of root type; default is generated from the filename`).String()
+	rootNodeName    = kingpin.Flag("root-node", `name of root node of json; default is whole file`).String()
 	typeNamesPrefix = kingpin.Flag("prefix", `prefix for non-root types`).String()
 	inputFile       = kingpin.Arg("input", "file containing a valid JSON schema").Required().ExistingFile()
 )
@@ -690,8 +691,22 @@ func main() {
 	}
 
 	var s metaSchema
-	if err = json.Unmarshal(file, &s); err != nil {
-		log.Fatalln("Error parsing JSON:", err)
+	if *rootNodeName != "" {
+
+		var sub map[string]metaSchema
+		if err = json.Unmarshal(file, &sub); err != nil {
+			log.Fatalln("Error parsing JSON:", err)
+		}
+		node, ok := sub[*rootNodeName]
+		if ok == false {
+			log.Fatalln(fmt.Sprintf("Error JSON node '%s' does not exists:", *rootNodeName), err)
+		}
+		//log.Panicf("Error reading file %v:", node)
+		s = node
+	} else {
+		if err = json.Unmarshal(file, &s); err != nil {
+			log.Fatalln("Error parsing JSON:", err)
+		}
 	}
 
 	schemaName := strings.Split(filepath.Base(*inputFile), ".")[0]


### PR DESCRIPTION
In some cases  I can get json with multiple schemas  for example  REST definition  GET/POST/DELETE etc.
This change will try to find node in json and  use it as  schema.