### PR TITLE
add inline option to embeded struct's json tag

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -109,6 +109,8 @@ func (gt goType) print(buf *bytes.Buffer) {
 				tagString += ",omitempty"
 			}
 			tagString += "\"`"
+		} else {
+			tagString = "`json:\",inline\"`"
 		}
 		buf.WriteString(fmt.Sprintf("%s %s %s\n", sf.Name, sfTypeStr, tagString))
 	}


### PR DESCRIPTION
Embedded structs are generated without any explicit json tag, leaving the interpretation of the embedded struct ambiguous. Adding the `inline` option to the embedded struct's json tag.